### PR TITLE
Some more ways to load/save the graph data

### DIFF
--- a/graph-creator.js
+++ b/graph-creator.js
@@ -230,6 +230,55 @@
     d3.select("#center-graph").on("click", function(){
       thisGraph.centerGraph();
     });
+    
+    // copy json to clipboard
+    d3.select("#copy-json").on("click", function(e) {
+      thisGraph._toggle_key_events_listen(false);
+      var saveEdges = [];
+      thisGraph.edges.forEach(function(val, i) {
+        saveEdges.push({
+            source: val.source.id,
+            target: val.target.id,
+            color: val.color,
+            stroke: val.stroke,
+            dir: val.dir,
+            fint: val.fint
+        });
+      });
+      var json = window.JSON.stringify({
+        "nodes": thisGraph.nodes,
+        "edges": saveEdges
+      });
+
+      alertify.prompt("Copy JSON", "Copy JSON to the clipboard?", json,
+        function save(e, name) {
+            thisGraph._toggle_key_events_listen(true);
+            document.execCommand("copy");
+        },
+        function noop() {
+            thisGraph._toggle_key_events_listen(true);
+        }
+      );
+    });
+
+    // load graph from pasted json
+    d3.select("#load-json").on("click", function() {
+      thisGraph._toggle_key_events_listen(false);
+      alertify.prompt("Load JSON", "Paste or type the JSON you want to load:", "",
+        function save(e, json) {
+          thisGraph._toggle_key_events_listen(true);
+          try {
+            thisGraph.load_graph_from_json(json);
+          } catch (err) {
+            alertify.alert('Ups!', "Error parsing JSON\nerror message: " + err.message);
+            return;
+          }
+        },
+        function noop() {
+         thisGraph._toggle_key_events_listen(true);
+        }
+      );
+    });
   };
 
   GraphCreator.prototype.setIdCt = function(idct){

--- a/mindcraft.html
+++ b/mindcraft.html
@@ -16,6 +16,8 @@
       <i id="delete-graph" title="Delete" alt="Delete" class="fa fa-trash" aria-hidden="true"></i>
       <i id="center-graph" title="Center" alt="Center" class="fa fa-share-alt-square" aria-hidden="true"></i>
       <i id="download-image" title="As Image" alt="As Image" class="fa fa-file-image-o" aria-hidden="true"></i>
+      <i id="load-json" title="Load JSON" alt="Load JSON" class="fa fa-paste" aria-hidden="true"></i>
+      <i id="copy-json" title="Copy JSON" alt="Copy JSON" class="fa fa-copy" aria-hidden="true"></i>
     </div>
     </div>
 

--- a/mindcraft.html
+++ b/mindcraft.html
@@ -14,7 +14,7 @@
       <i id="upload-input" title="Load" alt="Load" class="fa fa-upload" aria-hidden="true"></i> 
       <i id="download-input" title="Save" alt="Save" class="fa fa-download" aria-hidden="true"></i>
       <i id="delete-graph" title="Delete" alt="Delete" class="fa fa-trash" aria-hidden="true"></i>
-      <i id="center-graph" title="Center" alt="Center" class="fa fa-share-alt-square" aria-hidden="true"></i>
+      <i id="center-graph" title="Center" alt="Center" class="fa fa-bullseye" aria-hidden="true"></i>
       <i id="download-image" title="As Image" alt="As Image" class="fa fa-file-image-o" aria-hidden="true"></i>
       <i id="load-json" title="Load JSON" alt="Load JSON" class="fa fa-paste" aria-hidden="true"></i>
       <i id="copy-json" title="Copy JSON" alt="Copy JSON" class="fa fa-copy" aria-hidden="true"></i>


### PR DESCRIPTION
I've added a way to paste data directly into an alertify prompt in case people don't want to create a file specifically for a graph, and also a way to copy graphs into the clipboard without creating a new file. I think this would smoothly fit into your repository.

I might also add some features later in case you're interested: I've got a branch which lays out the nodes using Graphviz's Viz library.